### PR TITLE
fix: remove hardcoded date parameters from Calendly URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -529,7 +529,6 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-7.4.4.tgz",
       "integrity": "sha512-xzjxpr+d2zwTpCaN0k+C6wKSZzWFAb9OVEUtmO72ihjr/NEDoLvsGl4WLfjWPcCO2zOy0b2X52tfRWjECFUjtw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -1157,7 +1156,6 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -1551,7 +1549,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1753,7 +1750,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3588,7 +3584,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3741,7 +3736,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -6965,7 +6959,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7019,7 +7012,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"

--- a/src/components/Agendar.jsx
+++ b/src/components/Agendar.jsx
@@ -14,14 +14,14 @@ const substituto = {
   nome: 'Vinícius (Substituto Temporário)',
   // ALTERAÇÃO 1: Novo caminho da foto para o Vinícius (vinicius.png)
   foto: '/images/vinicius.png',        
-  calendlyUrl: 'https://calendly.com/temoteolucena/30min?back=1&month=2024-06', // Mesma URL do Temoteo
+  calendlyUrl: 'https://calendly.com/temoteolucena/30min', // Mesma URL do Temoteo
 };
 
 // Dados originais do Temoteo (para fácil reversão)
 const temoteoOriginal = {
   nome: 'Temoteo',
   foto: '/images/temoteo.jpg',
-  calendlyUrl: 'https://calendly.com/temoteolucena/30min?back=1&month=2024-06',
+  calendlyUrl: 'https://calendly.com/temoteolucena/30min',
 };
 
 // === FIM: NOVAS VARIÁVEIS DE CONTROLE ===
@@ -37,7 +37,7 @@ function Agendar() {
       nome: 'Ivan',
       // ALTERAÇÃO 2: Novo caminho da foto para o Ivan (lucena.png)
       foto: '/images/lucena.png',
-      calendlyUrl: 'https://calendly.com/lucenabarbearia013/lucena-barbearia?back=1&month=2024-06',
+      calendlyUrl: 'https://calendly.com/lucenabarbearia013/lucena-barbearia',
     },
     // Condição para exibir Temoteo ou o Substituto Vinícius
     IS_TEMOTEO_ON_VACATION


### PR DESCRIPTION
Removed hardcoded date parameters from Calendly URLs in `src/components/Agendar.jsx` to resolve the scheduling error.

---
*PR created automatically by Jules for task [3265069883516662364](https://jules.google.com/task/3265069883516662364) started by @gustavo-marcialis*